### PR TITLE
Support java.time.Instant type

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/ClockGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/ClockGenerator.java
@@ -1,13 +1,15 @@
 package org.javaunit.autoparams.generator;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
 final class ClockGenerator implements ObjectGenerator {
 
     @Override
     public ObjectContainer generate(ObjectQuery query, ObjectGenerationContext context) {
+
         return query.getType().equals(Clock.class)
-            ? new ObjectContainer(Clock.systemDefaultZone())
+            ? new ObjectContainer(Clock.system(context.generate(ZoneId.class)))
             : ObjectContainer.EMPTY;
     }
 

--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/InstantGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/InstantGenerator.java
@@ -1,0 +1,21 @@
+package org.javaunit.autoparams.generator;
+
+import java.time.Instant;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class InstantGenerator implements ObjectGenerator {
+
+    @Override
+    public ObjectContainer generate(ObjectQuery query, ObjectGenerationContext context) {
+        return query.getType().equals(Instant.class)
+            ? new ObjectContainer(factory())
+            : ObjectContainer.EMPTY;
+    }
+
+    private Instant factory() {
+        int bound = (int) TimeUnit.DAYS.toSeconds(7);
+        int seconds = ThreadLocalRandom.current().nextInt(bound);
+        return Instant.now().minusSeconds(seconds);
+    }
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/OffsetDateTimeGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/OffsetDateTimeGenerator.java
@@ -1,9 +1,8 @@
 package org.javaunit.autoparams.generator;
 
-import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import java.time.ZoneId;
 
 final class OffsetDateTimeGenerator implements ObjectGenerator {
 
@@ -15,10 +14,10 @@ final class OffsetDateTimeGenerator implements ObjectGenerator {
     }
 
     private OffsetDateTime factory(ObjectGenerationContext context) {
-        int bound = (int) TimeUnit.DAYS.toSeconds(7);
-        int seconds = ThreadLocalRandom.current().nextInt(bound);
-        Clock clock = context.generate(Clock.class);
-        return OffsetDateTime.now(clock).minusSeconds(seconds);
+        ZoneId zoneId = context.generate(ZoneId.class);
+        Instant instant = context.generate(Instant.class);
+
+        return OffsetDateTime.ofInstant(instant, zoneId);
     }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/SimpleValueObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/SimpleValueObjectGenerator.java
@@ -29,7 +29,8 @@ final class SimpleValueObjectGenerator extends CompositeObjectGenerator {
             new ClockGenerator(),
             new OffsetDateTimeGenerator(),
             new ZonedDateTimeGenerator(),
-            new ZoneIdGenerator()
+            new ZoneIdGenerator(),
+            new InstantGenerator()
         );
     }
 

--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/ZonedDateTimeGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/ZonedDateTimeGenerator.java
@@ -1,6 +1,6 @@
 package org.javaunit.autoparams.generator;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -13,8 +13,8 @@ public class ZonedDateTimeGenerator implements ObjectGenerator {
     }
 
     private ZonedDateTime factory(ObjectGenerationContext context) {
-        LocalDateTime localDateTime = context.generate(LocalDateTime.class);
+        Instant instant = context.generate(Instant.class);
         ZoneId zoneId = context.generate(ZoneId.class);
-        return localDateTime.atZone(zoneId);
+        return instant.atZone(zoneId);
     }
 }

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForClock.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForClock.java
@@ -1,0 +1,37 @@
+package org.javaunit.autoparams.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.javaunit.autoparams.AutoSource;
+import org.javaunit.autoparams.customization.Fix;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class SpecsForClock {
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_create_clock(Clock clock) {
+
+        assertNotNull(clock);
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_create_clock_with_fixed_zoneId(@Fix ZoneId zoneId, Clock clock) {
+
+        assertEquals(zoneId, clock.getZone());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_creates_randomized_clock(Clock value1, Clock value2, Clock value3) {
+
+        assertNotEquals(value1, value2);
+        assertNotEquals(value2, value3);
+        assertNotEquals(value3, value1);
+    }
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForInstant.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForInstant.java
@@ -1,0 +1,25 @@
+package org.javaunit.autoparams.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Instant;
+import org.javaunit.autoparams.AutoSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class SpecsForInstant {
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_creates_Instant_value(Instant instant) {
+        assertNotNull(instant);
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_creates_randomized_instant_value(Instant value1, Instant value2, Instant value3) {
+        assertNotEquals(value1, value2);
+        assertNotEquals(value2, value3);
+        assertNotEquals(value3, value1);
+    }
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForOffsetDateTime.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForOffsetDateTime.java
@@ -1,9 +1,14 @@
 package org.javaunit.autoparams.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import org.javaunit.autoparams.AutoSource;
+import org.javaunit.autoparams.customization.Fix;
 import org.junit.jupiter.params.ParameterizedTest;
 
 class SpecsForOffsetDateTime {
@@ -11,6 +16,7 @@ class SpecsForOffsetDateTime {
     @ParameterizedTest(name = ParameterizedTest.DISPLAY_NAME_PLACEHOLDER)
     @AutoSource
     void sut_creates_OffsetDateTime_value(OffsetDateTime arg) {
+        assertNotNull(arg);
     }
 
     @ParameterizedTest(name = ParameterizedTest.DISPLAY_NAME_PLACEHOLDER)
@@ -21,6 +27,13 @@ class SpecsForOffsetDateTime {
         assertThat(arg1).isNotEqualTo(arg2);
         assertThat(arg2).isNotEqualTo(arg3);
         assertThat(arg3).isNotEqualTo(arg1);
+    }
+
+    @ParameterizedTest(name = ParameterizedTest.DISPLAY_NAME_PLACEHOLDER)
+    @AutoSource
+    void sut_creates_fixed_OffsetDateTime_value(@Fix ZoneId zoneId, @Fix Instant instant,
+                                                OffsetDateTime arg) {
+        assertEquals(instant.atZone(zoneId).toOffsetDateTime(), arg);
     }
 
 }

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForZonedDateTime.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForZonedDateTime.java
@@ -4,13 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.javaunit.autoparams.AutoSource;
 import org.javaunit.autoparams.customization.Fix;
 import org.junit.jupiter.params.ParameterizedTest;
 
-public class SpecsForZonedDateTime {
+class SpecsForZonedDateTime {
 
     @ParameterizedTest
     @AutoSource
@@ -34,5 +35,13 @@ public class SpecsForZonedDateTime {
         @Fix ZoneId fixedZoneId, ZonedDateTime zonedDateTime
     ) {
         assertEquals(fixedZoneId, zonedDateTime.getZone());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_fixes_value_by_ZoneId_and_Instant(
+        @Fix ZoneId zoneId, @Fix Instant instant, ZonedDateTime zonedDateTime
+    ) {
+        assertEquals(instant.atZone(zoneId), zonedDateTime);
     }
 }


### PR DESCRIPTION
https://github.com/JavaUnit/AutoParams/issues/70

- Add `java.time.Instant` type generator
- Refactor some generators which are related to `java.time` package to use `InstantGenerator` and `ZoneIdGenerator` for fixing value.
  - `ClockGenerator`, `OffsetDateTimeGenerator`, `ZonedDateTimeGenerator`