### PR TITLE
Add KotlinCustomizer for kotlin class constructor having default value

### DIFF
--- a/autoparams-kotlin-test/build.gradle
+++ b/autoparams-kotlin-test/build.gradle
@@ -5,8 +5,9 @@ plugins {
 }
 
 dependencies {
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib"
-    testImplementation(project(":autoparams"))
+    implementation(project(":autoparams"))
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation "org.jetbrains.kotlin:kotlin-reflect"
     testImplementation 'org.assertj:assertj-core:3.20.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }

--- a/autoparams-kotlin-test/src/main/kotlin/autoparams/kotlin/ConstructorResolverGenerator.kt
+++ b/autoparams-kotlin-test/src/main/kotlin/autoparams/kotlin/ConstructorResolverGenerator.kt
@@ -1,0 +1,44 @@
+package autoparams.kotlin
+
+import autoparams.generator.ConstructorResolver
+import autoparams.generator.ObjectContainer
+import autoparams.generator.ObjectGenerator
+import java.beans.ConstructorProperties
+import java.util.Optional
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.javaConstructor
+
+internal class ConstructorResolverGenerator : ObjectGenerator {
+
+    private val value: ObjectContainer = ObjectContainer(
+        ConstructorResolver
+            .compose(
+                ConstructorResolver { t: Class<*> ->
+                    kotlin.runCatching { t.kotlin.primaryConstructor?.javaConstructor }
+                        .getOrNull()
+                        .let { Optional.ofNullable(it) }
+                },
+                ConstructorResolver { t: Class<*> ->
+                    t.constructors
+                        .filter { it.isAnnotationPresent(ConstructorProperties::class.java) }
+                        .minByOrNull { it.parameterCount }
+                        .let { Optional.ofNullable(it) }
+                },
+                ConstructorResolver { t: Class<*> ->
+                    t.constructors
+                        .minByOrNull { it.parameterCount }
+                        .let { Optional.ofNullable(it) }
+                }
+            )
+    )
+
+    override fun generate(
+        query: autoparams.generator.ObjectQuery,
+        context: autoparams.generator.ObjectGenerationContext
+    ): ObjectContainer {
+        return if (query.type === ConstructorResolver::class.java)
+            value
+        else
+            ObjectContainer.EMPTY
+    }
+}

--- a/autoparams-kotlin-test/src/main/kotlin/autoparams/kotlin/KotlinCustomizer.kt
+++ b/autoparams-kotlin-test/src/main/kotlin/autoparams/kotlin/KotlinCustomizer.kt
@@ -1,0 +1,14 @@
+package autoparams.kotlin
+
+import autoparams.customization.Customizer
+import autoparams.generator.CompositeObjectGenerator
+import autoparams.generator.ObjectGenerator
+
+class KotlinCustomizer : Customizer {
+    override fun customize(generator: ObjectGenerator): ObjectGenerator {
+        return CompositeObjectGenerator(
+            ConstructorResolverGenerator(),
+            generator,
+        )
+    }
+}

--- a/autoparams-kotlin-test/src/test/kotlin/autoparams/test/SpecsForPrimaryConstructor.kt
+++ b/autoparams-kotlin-test/src/test/kotlin/autoparams/test/SpecsForPrimaryConstructor.kt
@@ -1,0 +1,27 @@
+package autoparams.test
+
+import autoparams.AutoSource
+import autoparams.customization.Customization
+import autoparams.kotlin.KotlinCustomizer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+
+internal class SpecsForPrimaryConstructor {
+
+    data class HavingDefaultValueForConstructorParameter(
+        val value1: String = "default value",
+        val value2: List<Int> = emptyList(),
+        val value3: Long = 0,
+    )
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(KotlinCustomizer::class)
+    internal fun sut_creates_with_primary_constructor(fixture: HavingDefaultValueForConstructorParameter) {
+        val defaultValue = HavingDefaultValueForConstructorParameter()
+        assertThat(fixture.value1).isNotEqualTo(defaultValue.value1)
+        assertThat(fixture.value2).isNotEqualTo(defaultValue.value2)
+        assertThat(fixture.value3).isNotEqualTo(defaultValue.value3)
+    }
+
+}

--- a/autoparams/src/main/java/autoparams/generator/ComplexObjectGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/ComplexObjectGenerator.java
@@ -1,7 +1,6 @@
 package autoparams.generator;
 
 import autoparams.Builder;
-import java.beans.ConstructorProperties;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
@@ -9,7 +8,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -32,7 +30,7 @@ final class ComplexObjectGenerator implements ObjectGenerator {
             return ObjectContainer.EMPTY;
         }
 
-        Constructor<?> constructor = resolveConstructor(type);
+        Constructor<?> constructor = resolveConstructor(type, context);
         Stream<ObjectQuery> argumentQueries = Arrays
             .stream(constructor.getParameters())
             .map(ObjectQuery::fromParameter);
@@ -50,7 +48,7 @@ final class ComplexObjectGenerator implements ObjectGenerator {
         }
 
         Map<TypeVariable<?>, Type> genericMap = getGenericMap(type, parameterizedType);
-        Constructor<?> constructor = resolveConstructor(type);
+        Constructor<?> constructor = resolveConstructor(type, context);
         Stream<ObjectQuery> argumentQueries = Arrays
             .stream(constructor.getParameters())
             .map(parameter -> resolveArgumentQuery(parameter, genericMap));
@@ -61,17 +59,12 @@ final class ComplexObjectGenerator implements ObjectGenerator {
         return type.isInterface() || Modifier.isAbstract(type.getModifiers());
     }
 
-    private Constructor<?> resolveConstructor(Class<?> type) {
-        return ConstructorResolver
-            .compose(
-                t -> Arrays
-                    .stream(t.getConstructors())
-                    .filter(c -> c.isAnnotationPresent(ConstructorProperties.class))
-                    .min(Comparator.comparing(Constructor::getParameterCount)),
-                t -> Arrays
-                    .stream(t.getConstructors())
-                    .min(Comparator.comparing(Constructor::getParameterCount))
-            )
+    private Constructor<?> resolveConstructor(
+        Class<?> type,
+        ObjectGenerationContext context
+    ) {
+        final ConstructorResolver resolver = context.generate(ConstructorResolver.class);
+        return resolver
             .resolve(type)
             .orElseThrow(() -> new RuntimeException(
                 "Class '" + type.getName() + "' has no public constructor."));

--- a/autoparams/src/main/java/autoparams/generator/ConstructorResolver.java
+++ b/autoparams/src/main/java/autoparams/generator/ConstructorResolver.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Optional;
 
-interface ConstructorResolver {
+public interface ConstructorResolver {
 
     Optional<Constructor<?>> resolve(Class<?> type);
 

--- a/autoparams/src/main/java/autoparams/generator/ConstructorResolverGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/ConstructorResolverGenerator.java
@@ -1,0 +1,30 @@
+package autoparams.generator;
+
+import java.beans.ConstructorProperties;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Comparator;
+
+final class ConstructorResolverGenerator implements ObjectGenerator {
+
+    private final ObjectContainer value = new ObjectContainer(
+        ConstructorResolver
+            .compose(
+                t -> Arrays
+                    .stream(t.getConstructors())
+                    .filter(c -> c.isAnnotationPresent(ConstructorProperties.class))
+                    .min(Comparator.comparing(Constructor::getParameterCount)),
+                t -> Arrays
+                    .stream(t.getConstructors())
+                    .min(Comparator.comparing(Constructor::getParameterCount))
+            )
+    );
+
+    @Override
+    public ObjectContainer generate(ObjectQuery query, ObjectGenerationContext context) {
+        return query.getType() == ConstructorResolver.class
+            ? value
+            : ObjectContainer.EMPTY;
+    }
+
+}

--- a/autoparams/src/main/java/autoparams/generator/DefaultObjectGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/DefaultObjectGenerator.java
@@ -8,6 +8,7 @@ final class DefaultObjectGenerator extends CompositeObjectGenerator {
         super(
             new RecursionGuard().customize(
                 new CompositeObjectGenerator(
+                    new ConstructorResolverGenerator(),
                     new ObjectGenerationContextGenerator(),
                     new PrimitiveValueGenerator(),
                     new SimpleValueObjectGenerator(),


### PR DESCRIPTION
## Purpose

Solve the problem that `ComplexObjectGenerator` does not use primary constructor of kotlin class.

## Summary

As in the code below, you can apply Kotlin settings using `KotlinCustomizer`
Unlike PR #290, the core module does not reference Kotlin modules.

```kotlin
@ParameterizedTest
@AutoSource
@Customization(KotlinCustomizer::class)
fun sut_creates_with_primary_constructor(fixture: HavingDefaultValueForConstructorParameter) {
    val defaultValue = HavingDefaultValueForConstructorParameter()
    assertThat(fixture.value1).isNotEqualTo(defaultValue.value1)
    assertThat(fixture.value2).isNotEqualTo(defaultValue.value2)
    assertThat(fixture.value3).isNotEqualTo(defaultValue.value3)
}

data class HavingDefaultValueForConstructorParameter(
    val value1: String = "default value",
    val value2: List<Int> = emptyList(),
    val value3: Long = 0,
)
```

## Review Guide

- Please view the commits in order

## TODO

- [ ] Add deployment settings for kotlin module
- [ ] Documentation about Kotlin support (+Add troubleshooting guide about kotlin support)