### PR TITLE
Apply range annotations to float value generation and enhance error message to double value

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,10 @@ void testMethod(@Min(1) @Max(10) int value) {
 
 - `int`
 - `Integer`
+- `float`
+- `Float`
+- `double`
+- `Double`
 
 ### `@Customization` annotation
 

--- a/autoparams/src/main/java/autoparams/generator/DoubleGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/DoubleGenerator.java
@@ -1,5 +1,6 @@
 package autoparams.generator;
 
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.validation.constraints.Max;
@@ -23,9 +24,18 @@ final class DoubleGenerator implements ObjectGenerator {
     private double getOrigin(ObjectQuery query) {
         if (query instanceof ParameterQuery) {
             ParameterQuery argumentQuery = (ParameterQuery) query;
-            Min annotation = argumentQuery.getParameter().getAnnotation(Min.class);
-            if (annotation != null) {
-                return annotation.value();
+            Parameter parameter = argumentQuery.getParameter();
+            Min min = parameter.getAnnotation(Min.class);
+            if (min != null) {
+                Max max = parameter.getAnnotation(Max.class);
+                if (max == null) {
+                    throw new RuntimeException(
+                        "The parameter annotated with @Min is missing the"
+                            + " required @Max annotation. Please annotate the"
+                            + " parameter with both @Min and @Max annotations to"
+                            + " specify the minimum and maximum allowed values.");
+                }
+                return min.value();
             }
         }
 

--- a/autoparams/src/main/java/autoparams/generator/FloatGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/FloatGenerator.java
@@ -1,0 +1,57 @@
+package autoparams.generator;
+
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.concurrent.ThreadLocalRandom;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+final class FloatGenerator implements ObjectGenerator {
+
+    @Override
+    public ObjectContainer generate(ObjectQuery query, ObjectGenerationContext context) {
+        Type type = query.getType();
+        if (type == float.class || type == Float.class) {
+            float origin = getOrigin(query);
+            float bound = getBound(query);
+            float value = (float) ThreadLocalRandom.current().nextDouble(origin, bound);
+            return new ObjectContainer(value);
+        }
+
+        return ObjectContainer.EMPTY;
+    }
+
+    private float getBound(ObjectQuery query) {
+        if (query instanceof ParameterQuery) {
+            ParameterQuery argumentQuery = (ParameterQuery) query;
+            Max max = argumentQuery.getParameter().getAnnotation(Max.class);
+            if (max != null) {
+                return max.value();
+            }
+        }
+
+        return 1.0f;
+    }
+
+    private float getOrigin(ObjectQuery query) {
+        if (query instanceof ParameterQuery) {
+            ParameterQuery argumentQuery = (ParameterQuery) query;
+            Parameter parameter = argumentQuery.getParameter();
+            Min min = parameter.getAnnotation(Min.class);
+            if (min != null) {
+                Max max = parameter.getAnnotation(Max.class);
+                if (max == null) {
+                    throw new RuntimeException(
+                        "The parameter annotated with @Min is missing the"
+                        + " required @Max annotation. Please annotate the"
+                        + " parameter with both @Min and @Max annotations to"
+                        + " specify the minimum and maximum allowed values.");
+                }
+                return min.value();
+            }
+        }
+
+        return 0.0f;
+    }
+
+}

--- a/autoparams/src/main/java/autoparams/generator/PrimitiveValueGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/PrimitiveValueGenerator.java
@@ -4,13 +4,13 @@ final class PrimitiveValueGenerator extends CompositeObjectGenerator {
 
     public PrimitiveValueGenerator() {
         super(
-            new IntegerGenerator(),
-            new DoubleGenerator(),
-            new LongGenerator(),
             new TypeMatchingGenerator(Factories::createBoolean, boolean.class, Boolean.class),
+            new IntegerGenerator(),
+            new LongGenerator(),
             new ByteGenerator(),
             new ShortGenerator(),
-            new TypeMatchingGenerator(Factories::createFloat, float.class, Float.class),
+            new FloatGenerator(),
+            new DoubleGenerator(),
             new TypeMatchingGenerator(Factories::createChar, char.class, Character.class));
     }
 

--- a/autoparams/src/test/java/autoparams/test/SpecsForMax.java
+++ b/autoparams/src/test/java/autoparams/test/SpecsForMax.java
@@ -244,4 +244,11 @@ class SpecsForMax {
 
     void consumeByte(@Min(126) @Max(Byte.MAX_VALUE) byte arg) {
     }
+
+    @ParameterizedTest
+    @AutoSource
+    @Repeat(100)
+    void sut_accepts_max_constraint_for_float(@Max(100) float value) {
+        assertThat(value).isLessThanOrEqualTo(100);
+    }
 }

--- a/autoparams/src/test/java/autoparams/test/SpecsForMin.java
+++ b/autoparams/src/test/java/autoparams/test/SpecsForMin.java
@@ -34,6 +34,30 @@ public class SpecsForMin {
 
     @ParameterizedTest
     @AutoSource
+    void sut_does_not_accept_min_constraint_without_max_constraint_for_double(
+        ObjectGenerationContext context
+    ) throws NoSuchMethodException {
+        Method method = getClass().getDeclaredMethod(
+            "hasDoubleParameterWithOnlyMinAnnotation",
+            double.class
+        );
+        Parameter parameter = method.getParameters()[0];
+        ObjectQuery query = ObjectQuery.fromParameter(parameter);
+
+        assertThatThrownBy(() -> context.generate(query))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage(
+                "The parameter annotated with @Min is missing the required"
+                + " @Max annotation. Please annotate the parameter with"
+                + " both @Min and @Max annotations to specify"
+                + " the minimum and maximum allowed values.");
+    }
+
+    void hasDoubleParameterWithOnlyMinAnnotation(@Min(100) double arg) {
+    }
+
+    @ParameterizedTest
+    @AutoSource
     @Repeat(10)
     void sut_accepts_min_constraint_for_long(@Min(100) long value) {
         assertThat(value).isGreaterThanOrEqualTo(100);

--- a/autoparams/src/test/java/autoparams/test/SpecsForMin.java
+++ b/autoparams/src/test/java/autoparams/test/SpecsForMin.java
@@ -139,4 +139,35 @@ public class SpecsForMin {
 
     void byteMinConstraintLessThanLowerBound(@Min(Byte.MIN_VALUE - 1) byte arg) {
     }
+
+    @ParameterizedTest
+    @AutoSource
+    @Repeat(100)
+    void sut_accepts_min_constraint_for_float(@Min(100) @Max(Short.MAX_VALUE) float value) {
+        assertThat(value).isGreaterThanOrEqualTo(100);
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_does_not_accept_min_constraint_without_max_constraint_for_float(
+        ObjectGenerationContext context
+    ) throws NoSuchMethodException {
+        Method method = getClass().getDeclaredMethod(
+            "hasFloatParameterWithOnlyMinAnnotation",
+            float.class
+        );
+        Parameter parameter = method.getParameters()[0];
+        ObjectQuery query = ObjectQuery.fromParameter(parameter);
+
+        assertThatThrownBy(() -> context.generate(query))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage(
+                "The parameter annotated with @Min is missing the required"
+                + " @Max annotation. Please annotate the parameter with"
+                + " both @Min and @Max annotations to specify"
+                + " the minimum and maximum allowed values.");
+    }
+
+    void hasFloatParameterWithOnlyMinAnnotation(@Min(100) float arg) {
+    }
 }


### PR DESCRIPTION
resolves #192 
resolves #193 
resolves #293 

- Add FloatGenerator to apply range annotation to float value
- Enhance the error message for cases where only the `@Min` annotation is used.
- Update README.md to add supported type for range annotation.
  (float, Float, double, Double)