### PR TITLE
Enhance error message to double value 

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,10 @@ void testMethod(@Min(1) @Max(10) int value) {
 
 - `int`
 - `Integer`
+- `float`
+- `Float`
+- `double`
+- `Double`
 
 ### `@Customization` annotation
 

--- a/autoparams/src/main/java/autoparams/generator/DoubleGenerator.java
+++ b/autoparams/src/main/java/autoparams/generator/DoubleGenerator.java
@@ -1,5 +1,6 @@
 package autoparams.generator;
 
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.validation.constraints.Max;
@@ -23,9 +24,18 @@ final class DoubleGenerator implements ObjectGenerator {
     private double getOrigin(ObjectQuery query) {
         if (query instanceof ParameterQuery) {
             ParameterQuery argumentQuery = (ParameterQuery) query;
-            Min annotation = argumentQuery.getParameter().getAnnotation(Min.class);
-            if (annotation != null) {
-                return annotation.value();
+            Parameter parameter = argumentQuery.getParameter();
+            Min min = parameter.getAnnotation(Min.class);
+            if (min != null) {
+                Max max = parameter.getAnnotation(Max.class);
+                if (max == null) {
+                    throw new RuntimeException(
+                        "The parameter annotated with @Min is missing the"
+                            + " required @Max annotation. Please annotate the"
+                            + " parameter with both @Min and @Max annotations to"
+                            + " specify the minimum and maximum allowed values.");
+                }
+                return min.value();
             }
         }
 

--- a/autoparams/src/test/java/autoparams/test/SpecsForMin.java
+++ b/autoparams/src/test/java/autoparams/test/SpecsForMin.java
@@ -34,6 +34,30 @@ public class SpecsForMin {
 
     @ParameterizedTest
     @AutoSource
+    void sut_does_not_accept_min_constraint_without_max_constraint_for_double(
+        ObjectGenerationContext context
+    ) throws NoSuchMethodException {
+        Method method = getClass().getDeclaredMethod(
+            "hasDoubleParameterWithOnlyMinAnnotation",
+            double.class
+        );
+        Parameter parameter = method.getParameters()[0];
+        ObjectQuery query = ObjectQuery.fromParameter(parameter);
+
+        assertThatThrownBy(() -> context.generate(query))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage(
+                "The parameter annotated with @Min is missing the required"
+                + " @Max annotation. Please annotate the parameter with"
+                + " both @Min and @Max annotations to specify"
+                + " the minimum and maximum allowed values.");
+    }
+
+    void hasDoubleParameterWithOnlyMinAnnotation(@Min(100) double arg) {
+    }
+
+    @ParameterizedTest
+    @AutoSource
     @Repeat(10)
     void sut_accepts_min_constraint_for_long(@Min(100) long value) {
         assertThat(value).isGreaterThanOrEqualTo(100);


### PR DESCRIPTION
resolves #293 

- Enhance the error message for cases where only the `@Min` annotation is used.
- Update README.md to add supported type for range annotation.
  (float, Float, double, Double)