### PR TITLE
Gradle 7.3 업그레이드

### DIFF
--- a/autoparams-kotlin/build.gradle
+++ b/autoparams-kotlin/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.4.32"
+    id "org.jetbrains.kotlin.jvm" version "1.5.32"
 }
 
 dependencies {

--- a/autoparams-lombok/build.gradle
+++ b/autoparams-lombok/build.gradle
@@ -15,6 +15,6 @@ java {
 }
 
 test {
-    dependsOn("editorconfigCheck", "checkstyleMain", "checkstyleTest")
+    dependsOn("checkstyleMain", "checkstyleTest")
     useJUnitPlatform()
 }

--- a/autoparams-lombok/lombok.config
+++ b/autoparams-lombok/lombok.config
@@ -1,1 +1,0 @@
-lombok.extern.findbugs.addSuppressFBWarnings = true

--- a/autoparams-mockito/build.gradle
+++ b/autoparams-mockito/build.gradle
@@ -15,6 +15,6 @@ java {
 }
 
 test {
-    dependsOn("editorconfigCheck", "checkstyleMain", "checkstyleTest")
+    dependsOn("checkstyleMain", "checkstyleTest")
     useJUnitPlatform()
 }

--- a/autoparams-test-kotlin/build.gradle
+++ b/autoparams-test-kotlin/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.4.32"
+    id "org.jetbrains.kotlin.jvm" version "1.5.32"
 }
 
 dependencies {

--- a/autoparams/build.gradle
+++ b/autoparams/build.gradle
@@ -19,6 +19,6 @@ java {
 }
 
 test {
-    dependsOn("editorconfigCheck", "checkstyleMain", "checkstyleTest")
+    dependsOn("checkstyleMain", "checkstyleTest", "jar")
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
-import com.github.spotbugs.snom.SpotBugsTask
-
 plugins {
     id "java"
     id "maven-publish"
     id "signing"
-    id "org.ec4j.editorconfig" version "0.0.3"
     id "checkstyle"
-    id "com.github.spotbugs" version "4.7.0"
 }
 
 allprojects {
@@ -20,9 +16,7 @@ allprojects {
 
 subprojects {
     apply plugin: "java"
-    apply plugin: "org.ec4j.editorconfig"
     apply plugin: "checkstyle"
-    apply plugin: "com.github.spotbugs"
     apply plugin: "maven-publish"
     apply plugin: "signing"
 
@@ -30,12 +24,6 @@ subprojects {
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-
-    editorconfig {
-        excludes = ["build"]
-    }
-
-    check.dependsOn editorconfigCheck
 
     checkstyle {
         configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
@@ -45,33 +33,6 @@ subprojects {
         maxErrors = 0
         maxWarnings = 0
     }
-
-    spotbugs {
-        ignoreFailures = false
-        reportLevel = "high"
-        spotbugsTest.enabled = false
-    }
-
-    tasks.withType(SpotBugsTask) {
-        reports {
-            text.enabled = true
-            xml.enabled = false
-            html.enabled = false
-        }
-    }
-
-    tasks.register("printSpotbugsMain") {
-        doLast {
-            File mainResult = file("${buildDir}/reports/spotbugs/main.txt")
-            if (mainResult.exists()) {
-                mainResult.readLines().forEach {
-                    println(it)
-                }
-            }
-        }
-    }
-
-    tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
     jar {
         manifest {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#299 이슈(JDK 17 지원 목적)를 해결한다.

주요 작업
- Gradle 버전 7.3으로 변경
- Gradle 7.3 호환을 위해 org.jetbrains.kotlin.jvm 버전을 1.5.32로 변경
- Gradle 7.3과 호환되지 않는 코드 검사 작업인 editorconfig와 spotbugs 제거(추후 호환 버전으로 복구될 수 있음)

이 PR의 모든 커밋은 문제 없이 빌드되며 마지막 커밋은 JDK8과 JDK17 두 환경 모두에서 성공적으로 빌드된다.