### PR TITLE
README에 Gradle-Groovy 분리 및 Gradle-Kotlin 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,12 +870,20 @@ For Maven, you can add the following dependency to your pom.xml:
 </dependency>
 ```
 
-#### Gradle
+#### Gradle-Groovy
 
-For Gradle, use:
+For Gradle-Groovy, use:
 
 ```groovy
 testImplementation 'io.github.autoparams:autoparams-kotlin:8.3.0'
+```
+
+#### Gradle-Kotlin
+
+For Gradle-Kotlin, use:
+
+```kotlin
+testImplementation("io.github.autoparams:autoparams-kotlin:8.3.0")
 ```
 
 ### `@AutoKotlinSource` Annotation

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ For Maven, you can add the following dependency to your pom.xml:
 </dependency>
 ```
 
-#### Gradle-Groovy
+#### Gradle (Groovy)
 
 For Gradle-Groovy, use:
 
@@ -878,7 +878,7 @@ For Gradle-Groovy, use:
 testImplementation 'io.github.autoparams:autoparams-kotlin:8.3.0'
 ```
 
-#### Gradle-Kotlin
+#### Gradle (Kotlin)
 
 For Gradle-Kotlin, use:
 


### PR DESCRIPTION
새로운 Gradle 빌드의 기본 언어로 Kotlin이 채택되었습니다.
Gradle-Kotlin을 사용하는 사용자 분들이 많을 것으로 예상되어, 복사가 더욱 편리하도록 작업을 진행하였습니다.