### PR TITLE
Introduce  @AutoParams annotation

### DIFF
--- a/autoparams/src/main/java/autoparams/AutoParams.java
+++ b/autoparams/src/main/java/autoparams/AutoParams.java
@@ -1,0 +1,14 @@
+package autoparams;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(AutoParamsExtension.class)
+public @interface AutoParams {
+}

--- a/autoparams/src/main/java/autoparams/AutoParamsExtension.java
+++ b/autoparams/src/main/java/autoparams/AutoParamsExtension.java
@@ -1,0 +1,43 @@
+package autoparams;
+
+import java.lang.reflect.Parameter;
+
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public final class AutoParamsExtension implements
+    BeforeTestExecutionCallback,
+    ParameterResolver {
+
+    private ResolutionContext resolutionContext = null;
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        resolutionContext = new ResolutionContext(context);
+    }
+
+    @Override
+    public boolean supportsParameter(
+        ParameterContext parameterContext,
+        ExtensionContext extensionContext
+    ) throws ParameterResolutionException {
+        return true;
+    }
+
+    @Override
+    public Object resolveParameter(
+        ParameterContext parameterContext,
+        ExtensionContext extensionContext
+    ) throws ParameterResolutionException {
+        Parameter parameter = parameterContext.getParameter();
+        ParameterQuery query = new ParameterQuery(
+            parameter,
+            parameterContext.getIndex(),
+            parameter.getParameterizedType()
+        );
+        return resolutionContext.resolve(query);
+    }
+}

--- a/autoparams/src/test/java/test/autoparams/SpecsForAutoParams.java
+++ b/autoparams/src/test/java/test/autoparams/SpecsForAutoParams.java
@@ -1,0 +1,14 @@
+package test.autoparams;
+
+import java.util.UUID;
+
+import autoparams.AutoParams;
+import org.junit.jupiter.api.Test;
+
+public class SpecsForAutoParams {
+
+    @Test
+    @AutoParams
+    void sut_resolves_arguments(String args1, UUID args2) {
+    }
+}


### PR DESCRIPTION
`@AutoParams` automatically provides arguments for test method parameters and can be used with the `@Test` annotation.