### PR TITLE
Support Kotlin property reference in set() DSL

### DIFF
--- a/autoparams/src/main/java/autoparams/customization/dsl/ArgumentCustomizationDsl.java
+++ b/autoparams/src/main/java/autoparams/customization/dsl/ArgumentCustomizationDsl.java
@@ -1,6 +1,5 @@
 package autoparams.customization.dsl;
 
-import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
@@ -8,7 +7,8 @@ import java.util.function.Predicate;
 import autoparams.ParameterQuery;
 import autoparams.type.TypeReference;
 
-import static autoparams.customization.dsl.ParameterNameInferencer.inferParameterName;
+import static autoparams.customization.dsl.GetterDelegate.getGetterOf;
+import static autoparams.customization.dsl.ParameterNameInferencer.inferParameterNameFromGetter;
 
 public final class ArgumentCustomizationDsl {
 
@@ -49,31 +49,13 @@ public final class ArgumentCustomizationDsl {
     public static <T, P> FreezeArgument set(
         FunctionDelegate<T, P> getterDelegate
     ) {
-        SerializedLambda lambda = getterDelegate.getLambda();
-        Class<?> componentType = getComponentClass(lambda);
-        Method getter = getMethod(componentType, lambda.getImplMethodName());
-        String parameterName = inferParameterName(getter.getName());
+        Method getter = getGetterOf(getterDelegate);
+        String parameterName = inferParameterNameFromGetter(getter);
         return new FreezeArgument(
             new ParameterTypeMatches(getter.getReturnType())
                 .and(new ParameterNameEquals(parameterName))
-                .and(new DeclaringClassEquals(componentType))
+                .and(new DeclaringClassEquals(getter.getDeclaringClass()))
         );
-    }
-
-    private static Class<?> getComponentClass(SerializedLambda lambda) {
-        try {
-            return Class.forName(lambda.getImplClass().replace('/', '.'));
-        } catch (ClassNotFoundException exception) {
-            throw new RuntimeException(exception);
-        }
-    }
-
-    private static Method getMethod(Class<?> type, String methodName) {
-        try {
-            return type.getMethod(methodName);
-        } catch (NoSuchMethodException exception) {
-            throw new RuntimeException(exception);
-        }
     }
 
     public static FreezeArgument freezeArgumentOf(Type parameterType) {

--- a/autoparams/src/main/java/autoparams/customization/dsl/FunctionDelegate.java
+++ b/autoparams/src/main/java/autoparams/customization/dsl/FunctionDelegate.java
@@ -2,22 +2,17 @@ package autoparams.customization.dsl;
 
 import java.io.Serializable;
 import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.function.Function;
 
 @FunctionalInterface
 public interface FunctionDelegate<T, R> extends Function<T, R>, Serializable {
 
+    /**
+     * This method was mistakenly added during refactoring and is not intended
+     * to be part of the API. It has been deprecated and should not be used.
+     */
+    @Deprecated
     default SerializedLambda getLambda() {
-        try {
-            Method method = getClass().getDeclaredMethod("writeReplace");
-            method.setAccessible(true);
-            return (SerializedLambda) method.invoke(this);
-        } catch (NoSuchMethodException |
-                 InvocationTargetException |
-                 IllegalAccessException exception) {
-            throw new RuntimeException(exception);
-        }
+        return GetterDelegate.getLambda(this);
     }
 }

--- a/autoparams/src/main/java/autoparams/customization/dsl/GetterDelegate.java
+++ b/autoparams/src/main/java/autoparams/customization/dsl/GetterDelegate.java
@@ -1,0 +1,74 @@
+package autoparams.customization.dsl;
+
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+class GetterDelegate {
+
+    public static <T, R> Method getGetterOf(FunctionDelegate<T, R> delegate) {
+        SerializedLambda lambda = getLambda(delegate);
+        return isInKotlin(lambda)
+            ? getKotlinGetter(lambda)
+            : getJavaGetter(lambda);
+    }
+
+    public static <T, R> SerializedLambda getLambda(
+        FunctionDelegate<T, R> delegate
+    ) {
+        try {
+            Method writeReplace = delegate
+                .getClass()
+                .getDeclaredMethod("writeReplace");
+            writeReplace.setAccessible(true);
+            return (SerializedLambda) writeReplace.invoke(delegate);
+        } catch (NoSuchMethodException |
+                 InvocationTargetException |
+                 IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private static boolean isInKotlin(SerializedLambda lambda) {
+        return lambda.getCapturedArgCount() == 1;
+    }
+
+    private static Method getKotlinGetter(SerializedLambda lambda) {
+        Object arg = lambda.getCapturedArg(0);
+        Object owner = invokeGetter(arg, "getOwner");
+        Class<?> componentType = invokeGetter(owner, "getJClass");
+        String signature = invokeGetter(arg, "getSignature");
+        String getterName = signature.substring(0, signature.indexOf('('));
+        return getGetter(componentType, getterName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T invokeGetter(Object instance, String getterName) {
+        try {
+            Method getter = instance.getClass().getMethod(getterName);
+            return (T) getter.invoke(instance);
+        } catch (NoSuchMethodException |
+                 IllegalAccessException |
+                 InvocationTargetException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private static Method getJavaGetter(SerializedLambda lambda) {
+        try {
+            String componentTypeName = lambda.getImplClass().replace('/', '.');
+            Class<?> componentType = Class.forName(componentTypeName);
+            return getGetter(componentType, lambda.getImplMethodName());
+        } catch (ClassNotFoundException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private static Method getGetter(Class<?> type, String getterName) {
+        try {
+            return type.getMethod(getterName);
+        } catch (NoSuchMethodException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/autoparams/src/main/java/autoparams/customization/dsl/ParameterNameInferencer.java
+++ b/autoparams/src/main/java/autoparams/customization/dsl/ParameterNameInferencer.java
@@ -1,15 +1,17 @@
 package autoparams.customization.dsl;
 
+import java.lang.reflect.Method;
+
 import static java.lang.Character.isUpperCase;
 import static java.lang.Character.toLowerCase;
 
 class ParameterNameInferencer {
 
-    public static String inferParameterName(String getterName) {
-        return decapitalizeFirstCharacter(removePrefix(getterName));
+    public static String inferParameterNameFromGetter(Method getter) {
+        return decapitalizeHead(removeGetterPrefix(getter.getName()));
     }
 
-    private static String removePrefix(String getterName) {
+    private static String removeGetterPrefix(String getterName) {
         if (hasIsPrefix(getterName)) {
             return getterName.substring(2);
         } else if (hasGetPrefix(getterName)) {
@@ -19,21 +21,20 @@ class ParameterNameInferencer {
         }
     }
 
-    private static boolean hasIsPrefix(String getterName) {
-        return getterName.startsWith("is")
-            && getterName.length() > 2
-            && isUpperCase(getterName.charAt(2));
+    private static boolean hasIsPrefix(String methodName) {
+        return methodName.startsWith("is")
+            && methodName.length() > 2
+            && isUpperCase(methodName.charAt(2));
     }
 
-    private static boolean hasGetPrefix(String getterName) {
-        return getterName.startsWith("get")
-            && getterName.length() > 3
-            && isUpperCase(getterName.charAt(3));
+    private static boolean hasGetPrefix(String methodName) {
+        return methodName.startsWith("get")
+            && methodName.length() > 3
+            && isUpperCase(methodName.charAt(3));
     }
 
-    private static String decapitalizeFirstCharacter(String name) {
-        return isUpperCase(name.charAt(0))
-            ? toLowerCase(name.charAt(0)) + name.substring(1)
-            : name;
+    private static String decapitalizeHead(String s) {
+        char head = s.charAt(0);
+        return isUpperCase(head) ? toLowerCase(head) + s.substring(1) : s;
     }
 }

--- a/test-autoparams-kotlin/build.gradle.kts
+++ b/test-autoparams-kotlin/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += "-java-parameters"
     }
 }
 

--- a/test-autoparams-kotlin/src/test/kotlin/test/autoparams/Product.kt
+++ b/test-autoparams-kotlin/src/test/kotlin/test/autoparams/Product.kt
@@ -1,0 +1,14 @@
+package test.autoparams
+
+import java.math.BigDecimal
+import java.util.UUID
+
+data class Product(
+    val id: UUID,
+    val name: String,
+    val imageUri: String,
+    val description: String,
+    val priceAmount: BigDecimal,
+    val stockQuantity: Int,
+    val displayed: Boolean
+)

--- a/test-autoparams-kotlin/src/test/kotlin/test/autoparams/customization/dsl/SpecsForDslInKotlin.kt
+++ b/test-autoparams-kotlin/src/test/kotlin/test/autoparams/customization/dsl/SpecsForDslInKotlin.kt
@@ -1,0 +1,22 @@
+package test.autoparams.customization.dsl
+
+import autoparams.ResolutionContext
+import autoparams.customization.dsl.ArgumentCustomizationDsl.set
+import autoparams.kotlin.AutoKotlinParams
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import test.autoparams.Product
+
+class SpecsForDslInKotlin {
+
+    @Test
+    @AutoKotlinParams
+    fun `set correctly sets argument`(
+        context: ResolutionContext,
+        name: String
+    ) {
+        context.customize(set(Product::name).to(name))
+        val product: Product = context.resolve()
+        assertThat(product.name).isEqualTo(name)
+    }
+}


### PR DESCRIPTION
Enable support for Kotlin property references in the set() DSL by resolving captured lambda metadata. This allows more idiomatic and concise customizations when using Kotlin.

Also marked FunctionDelegate<T, R>.getLambda() as deprecated. This method was unintentionally exposed in the 10.3.0 release and was never meant to be part of the public API.