### PR TITLE
Resolve type variables in generic test class hierarchies

### DIFF
--- a/autoparams/src/main/java/autoparams/TestResolutionContext.java
+++ b/autoparams/src/main/java/autoparams/TestResolutionContext.java
@@ -126,7 +126,23 @@ class TestResolutionContext extends ResolutionContext {
         }
 
         Type[] bounds = typeVariable.getBounds();
-        return bounds.length > 0 ? bounds[0] : Object.class;
+        Type fallbackType = bounds.length > 0 ? bounds[0] : Object.class;
+
+        String message = String.format(
+            "Failed to resolve type variable '%s' from test class "
+            + "hierarchy '%s'. Falling back to %s. "
+            + "This may indicate missing type parameter mapping in your "
+            + "test class hierarchy. For example, if you have "
+            + "'class MyTest extends BaseTest<T>', make sure to specify "
+            + "the type parameter like 'class MyTest extends BaseTest<MyType>'.",
+            typeVariable.getName(),
+            testClass.getName(),
+            TypeFormatter.format(fallbackType, false)
+        );
+
+        System.err.println("WARNING: " + message);
+
+        return fallbackType;
     }
 
     private Type resolveTypeVariableFromClass(

--- a/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
+++ b/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
@@ -126,4 +126,44 @@ public class SpecsForGenericTestClass {
     class CategoryRepositoryTest
         extends RepositoryTest<CategoryRepository, Category> {
     }
+
+    abstract static class UnboundTest<T> {
+        @ParameterizedTest
+        @AutoSource
+        void test_with_unbound_type(T value) {
+            assertNotNull(value);
+        }
+    }
+
+    @Nested
+    class ConcreteUnboundTest extends UnboundTest {
+    }
+
+    abstract static class BaseLevel<A> {
+        @ParameterizedTest
+        @AutoSource
+        void test_base(A value) {
+            assertNotNull(value);
+        }
+    }
+
+    abstract static class MiddleLevel<B> extends BaseLevel<B> {
+        @ParameterizedTest
+        @AutoSource
+        void test_middle(B value) {
+            assertNotNull(value);
+        }
+    }
+
+    abstract static class HigherLevel<C> extends MiddleLevel<C> {
+        @ParameterizedTest
+        @AutoSource
+        void test_higher(C value) {
+            assertNotNull(value);
+        }
+    }
+
+    @Nested
+    class ThreeLevelTest extends HigherLevel<Category> {
+    }
 }

--- a/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
+++ b/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
@@ -1,0 +1,55 @@
+package test.autoparams;
+
+import autoparams.AutoSource;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SpecsForGenericTestClass {
+
+    public abstract static class HierarchyEntity<T extends HierarchyEntity<T>> {
+        private T parent;
+
+        public void changeParent(T parent) {
+            this.parent = parent;
+        }
+
+        public T getParent() {
+            return parent;
+        }
+    }
+
+    public static class Category extends HierarchyEntity<Category> {
+        private final String name;
+
+        public Category(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    abstract static class HierarchyEntityTest<T extends HierarchyEntity<T>> {
+        @ParameterizedTest
+        @AutoSource
+        void sut_is_not_null(T sut) {
+            assertNotNull(sut);
+        }
+
+        @ParameterizedTest
+        @AutoSource
+        void changeParent(T sut, T parent) {
+            assertNotNull(sut);
+            assertNotNull(parent);
+            sut.changeParent(parent);
+            assertNotNull(sut.getParent());
+        }
+    }
+
+    @Nested
+    class CategoryTest extends HierarchyEntityTest<Category> {
+    }
+}

--- a/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
+++ b/autoparams/src/test/java/test/autoparams/SpecsForGenericTestClass.java
@@ -52,4 +52,78 @@ public class SpecsForGenericTestClass {
     @Nested
     class CategoryTest extends HierarchyEntityTest<Category> {
     }
+
+    public abstract static class MiddleEntity<U extends MiddleEntity<U>>
+        extends HierarchyEntity<U> {
+        private String description;
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    public static class Product extends MiddleEntity<Product> {
+        private final int id;
+
+        public Product(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    abstract static class MiddleEntityTest<U extends MiddleEntity<U>>
+        extends HierarchyEntityTest<U> {
+        @ParameterizedTest
+        @AutoSource
+        void setDescription(U sut, String description) {
+            assertNotNull(sut);
+            assertNotNull(description);
+            sut.setDescription(description);
+            assertNotNull(sut.getDescription());
+        }
+    }
+
+    @Nested
+    class ProductTest extends MiddleEntityTest<Product> {
+    }
+
+    public interface GenericRepository<T> {
+
+        void save(T entity);
+
+        T findById(int id);
+    }
+
+    public static class CategoryRepository implements GenericRepository<Category> {
+        @Override
+        public void save(Category entity) {
+        }
+
+        @Override
+        public Category findById(int id) {
+            return new Category("test");
+        }
+    }
+
+    abstract static class RepositoryTest<R extends GenericRepository<E>, E> {
+        @ParameterizedTest
+        @AutoSource
+        void save_entity(R repository, E entity) {
+            assertNotNull(repository);
+            assertNotNull(entity);
+            repository.save(entity);
+        }
+    }
+
+    @Nested
+    class CategoryRepositoryTest
+        extends RepositoryTest<CategoryRepository, Category> {
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #277 by implementing type variable resolution for generic test class hierarchies. When test methods are inherited from abstract generic test classes, AutoParams can now correctly resolve type parameters to their concrete types.

### Problem
Previously, when a test class like `CategoryTest extends HierarchyEntityTest<Category>` inherited test methods with generic parameters `T`, AutoParams failed with:
```
RuntimeException: Object cannot be created with the given query
```

This occurred because `parameter.getParameterizedType()` returned `TypeVariable` instead of the concrete type `Category`.

### Solution

Enhanced `TestResolutionContext` to:
- Detect `TypeVariable` parameters in test methods
- Walk the test class hierarchy to find type variable mappings
- Resolve type variables using the test class's generic superclass information
- Support multi-level inheritance and generic interfaces
- Handle recursive type variable resolution with defensive type checking

### Changes

**Modified**: `TestResolutionContext.java`
- Added `resolveTypeVariable()` - Main entry point for type resolution
- Added `resolveTypeVariableFromClass()` - Walks class hierarchy recursively
- Added `resolveTypeVariableFromType()` - Resolves from parameterized types with safe casting

**Added**: `SpecsForGenericTestClass.java`
- Tests single-level inheritance (`CategoryTest extends HierarchyEntityTest<Category>`)
- Tests multi-level inheritance (`ProductTest extends MiddleEntityTest<Product> extends HierarchyEntityTest`)
- Tests generic interface resolution (`CategoryRepositoryTest` with multiple type parameters)

### Test Coverage

All new tests pass, covering:
- ✅ Single-level generic inheritance
- ✅ Multi-level generic inheritance (3+ levels)
- ✅ Generic interfaces with type parameters
- ✅ Nested type variable chains
- ✅ Fallback to type bounds when resolution fails

### Build Status

```
BUILD SUCCESSFUL
All tests passing
Checkstyle compliant
```

### Example Usage

```java
abstract class HierarchyEntityTest<T extends HierarchyEntity<T>> {
    @ParameterizedTest
    @AutoSource
    void changeParent(T sut, T parent) {
        sut.changeParent(parent);
        // Assertions...
    }
}

class CategoryTest extends HierarchyEntityTest<Category> {
    // Tests now work! AutoParams resolves T -> Category
}
```

### Impact

- No breaking changes
- Backward compatible with existing test patterns
- Enables generic test base classes (common pattern in domain-driven design)
- Handles complex inheritance hierarchies robustly

### Review Notes

This PR addresses:
1. The original issue #277 (single-level inheritance)
2. Code review findings (multi-level inheritance, defensive casting)
3. Edge cases (generic interfaces, recursive resolution)

Ready for review and testing.