### PR TITLE
Fix Design.set for generic properties

### DIFF
--- a/autoparams/src/main/java/autoparams/customization/Design.java
+++ b/autoparams/src/main/java/autoparams/customization/Design.java
@@ -1,5 +1,7 @@
 package autoparams.customization;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -326,7 +328,13 @@ public class Design<T> implements Customizer {
         }
 
         private boolean matchesParameterType(ParameterQuery query) {
-            return property.getType().equals(query.getType());
+            Type queryType = query.getType();
+            if (queryType instanceof ParameterizedType) {
+                return property.getType().equals(
+                    ((ParameterizedType) queryType).getRawType()
+                );
+            }
+            return property.getType().equals(queryType);
         }
 
         private boolean matchesParameterName(ParameterQuery query) {

--- a/test-autoparams-java-17/src/test/java/test/autoparams/Product.java
+++ b/test-autoparams-java-17/src/test/java/test/autoparams/Product.java
@@ -1,6 +1,7 @@
 package test.autoparams;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public record Product(
@@ -10,6 +11,7 @@ public record Product(
     String imageUri,
     String description,
     BigDecimal priceAmount,
-    int stockQuantity
+    int stockQuantity,
+    List<String> tags
 ) {
 }

--- a/test-autoparams-java-17/src/test/java/test/autoparams/Product.java
+++ b/test-autoparams-java-17/src/test/java/test/autoparams/Product.java
@@ -2,6 +2,7 @@ package test.autoparams;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public record Product(
@@ -12,6 +13,7 @@ public record Product(
     String description,
     BigDecimal priceAmount,
     int stockQuantity,
-    List<String> tags
+    List<String> tags,
+    Map<String, List<String>> attributes
 ) {
 }

--- a/test-autoparams-java-17/src/test/java/test/autoparams/customization/SpecsForDesign.java
+++ b/test-autoparams-java-17/src/test/java/test/autoparams/customization/SpecsForDesign.java
@@ -395,6 +395,17 @@ class SpecsForDesign {
     }
 
     @Test
+    void set_correctly_sets_property_with_generic_type() {
+        List<String> tags = List.of("foo", "bar");
+
+        Product product = Design.of(Product.class)
+            .set(Product::tags, tags)
+            .instantiate();
+
+        assertThat(product.tags()).isEqualTo(tags);
+    }
+
+    @Test
     void customize_with_generator_throws_exception_when_generator_is_null() {
         Design<Product> design = Design.of(Product.class);
 

--- a/test-autoparams-java-17/src/test/java/test/autoparams/customization/SpecsForDesign.java
+++ b/test-autoparams-java-17/src/test/java/test/autoparams/customization/SpecsForDesign.java
@@ -1,6 +1,7 @@
 package test.autoparams.customization;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import autoparams.AutoParams;
@@ -403,6 +404,20 @@ class SpecsForDesign {
             .instantiate();
 
         assertThat(product.tags()).isEqualTo(tags);
+    }
+
+    @Test
+    void set_correctly_sets_property_with_nested_generic_type() {
+        Map<String, List<String>> attributes = Map.of(
+            "colors", List.of("red", "blue"),
+            "sizes", List.of("S", "M", "L")
+        );
+
+        Product product = Design.of(Product.class)
+            .set(Product::attributes, attributes)
+            .instantiate();
+
+        assertThat(product.attributes()).isEqualTo(attributes);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix `Design.set` method not working with generic type properties (e.g., `List<String> tags`)
- The root cause was `ArgumentSupplier.matchesParameterType` comparing a raw `Class` (e.g., `List.class`) with a `ParameterizedType` (e.g., `List<String>`), which always returned `false`
- Extract the raw type from `ParameterizedType` before comparison so generic properties match correctly

## Test plan

- [x] Added test `set_correctly_sets_property_with_generic_type` that verifies `Design.set(Product::tags, List.of("foo", "bar"))` works
- [x] All existing `SpecsForDesign` tests pass
- [x] All `autoparams` module tests pass

Closes #324

https://claude.ai/code/session_01UG1Vv5ASnPXaexQyowv7uW